### PR TITLE
running 100 Popen processes at a time instead of all simultaneously

### DIFF
--- a/zarr_etl_tools/utils/zarr_methods.py
+++ b/zarr_etl_tools/utils/zarr_methods.py
@@ -204,8 +204,16 @@ class Creation(Convenience):
                  )
         # Convert each comment to a Popen call b/c Popen doesn't block, hence processes will run in parallel
         processes = [ Popen(command) for command in commands ]
-        for process in processes:
-            process.wait()
+        # Only run 100 processes at a time to prevent BlockingIOErrors
+        for index in range(0, len(processes), 100):
+            process_slice = processes[index:index+100]
+            for process in process_slice:
+                process.wait()
+        else:
+            if len(processes) % 100:
+                process_slice = processes[index:]
+                for process in process_slice:
+                    process.wait()
         self.info(
             f"{(len(list(input_files)))} conversions finished, cleaning up original files"
         )


### PR DESCRIPTION
Addressing #20 by only passing 100 subprocess commands at a time.

This passes tests locally